### PR TITLE
do not use R 4.3 syntax

### DIFF
--- a/R/scopus_client.R
+++ b/R/scopus_client.R
@@ -793,8 +793,7 @@ parse_confinfo <- function(abstract) {
 
   source <-
     #eid |> scopus_req_abstract() |>  httr::content() |>
-    abstract |>
-    _$`abstracts-retrieval-response`$item$bibrecord$head$source
+    abstract$`abstracts-retrieval-response`$item$bibrecord$head$source
 
   event <- source$`additional-srcinfo`$conferenceinfo$confevent
 


### PR DESCRIPTION
According to "https://cran.r-project.org/doc/manuals/r-release/NEWS.html" : As an experimental feature the placeholder _ can now also be used in the rhs of a forward pipe |> expression as the first argument in an extraction call, such as _$coef. More generally, it can be used as the head of a chain of extractions, such as _$coef[[2]]. "

Avoid using _$ since base layers in containers may not support R v 4.3 (yet).