### PR TITLE
fix issue #210

### DIFF
--- a/inst/rmarkdown/report-mods/mods.qmd
+++ b/inst/rmarkdown/report-mods/mods.qmd
@@ -296,8 +296,8 @@ import <-
 sids_erratum <-
   import |>
   filter(
-    grepl("erratum", subtypeDescription) |
-    grepl("erratum", `prism:aggregationType`)
+    grepl("[Ee]rratum", subtypeDescription) |
+    grepl("[Ee]rratum", `prism:aggregationType`)
   ) |>
   pull(`dc:identifier`)
 


### PR DESCRIPTION
When generating MODSCollection batches, put all records from Scopus mentioning "erratum" in the subtypeDescription or prism:aggregationType in the "erratum" bucket.