### PR TITLE
Added OpenAlex author id as a legitimate "kthid"

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -743,7 +743,7 @@ check_invalid_kthid <- function(authors = kth_diva_authors()) {
   # TODO: multiple same kthids in one publication?
   # username in orcid field?
 
-  re_kthid <- "^u1[a-z0-9]{6}$"
+  re_kthid <- "^(?:u1[a-z0-9]{6}|[aA][0-9]{10})$"
   re_temp <- "^PI\\d+|P\\d+|pi\\d+|p\\d+|Pi\\d+|PI \\d+|-"
 
   ScopusId <- NULL


### PR DESCRIPTION
We are using OpenAlex ids when creating authority records for KTH researchers that existed before the present kth-id was introduced.